### PR TITLE
Feat/proper file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ To deploy this in your environment
 0) No warranty. Do this in your own responsibility.
 
 1) Place the contents of this repo somewhere in your homedirectory:
-```
+```bash
 $ cd
 $ mkdir tools
 $ cd tools
 $ git clone <this repo>
 ```
 2) Create a symbolic link to the tips diretory in your home directory:
-```
+```bash
 $ cd
 $ ln -s tools/tips
 ```
 3) Add calling for the script to the end of the .bashrc file of your home directory:
-```
+```bash
 $ cd 
-$ echo "sh tools/gittips/tips.sh" >> .basrch
+$ echo "./tools/gittips/tips.sh" >> .basrch
 ```
 4) Try out
-```
+```bash
 $ cd
 $ source .bashrc
 ```

--- a/tips.sh
+++ b/tips.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Configuration - set to 1, if tips are loaded from the server...
-TOTD_HTTP=1
+TOTD_HTTP=0
 
 # Default tips directory
 TIPREPO=~/tips

--- a/tips.sh
+++ b/tips.sh
@@ -1,37 +1,49 @@
 #!/bin/bash
 
-#TOTD_HTTP=1 # Configuration - set to 1, if tips from the server ...
-CURTIP=`cat ~/.curtip`
+# Configuration - set to 1, if tips are loaded from the server...
+TOTD_HTTP=1
 
-# If no value in the current index file, start from start
-if [ -z $CURTIP ] ; then
-  CURTIP=1
-fi
-
+# Default tips directory
 TIPREPO=~/tips
 
-if [ $TOTD_HTTP ] ; then
-  TIPLABEL="HTTP $CURTIP"
-  NUMTIPS=8 # This is not very clever and should be improved!
-else
-  NUMTIPS=`ls $TIPREPO/*.txt | wc -l`
-  TIPLABEL="$TIPREPO/$CURTIP.txt"
+# If no tips folder found in users home directory,
+# use folder in current working directory
+if [ ! -d $TIPREPO ] ; then
+  TIPREPO=./tips
 fi
 
+TIPS=()
+
+# Loop through files in a folder and
+# save them to $TIPS array
+for file in "$TIPREPO"/*
+do
+  # Capture file name only without path
+  TIPS+=( "${file##*/}" )
+done
+
+# Get a random index 
+rand=$[$RANDOM % ${#TIPS[@]}]
+
+# Select tip file
+SELECTED_TIP=${TIPS[$rand]}
+
+# Create label
+if [ $TOTD_HTTP -eq 1 ] ; then
+  TIPLABEL="HTTP $SELECTED_TIP"
+else
+  TIPLABEL="$TIPREPO/$SELECTED_TIP"
+fi
+
+# Print out the tip
 echo
 echo "================================================"
 echo " TIP OF TODAY ($TIPLABEL) "
 echo "------------------------------------------------"
-if [ $TOTD_HTTP ] ; then
-  curl http://192.168.3.16/tips/$CURTIP.txt 2>/dev/null
+if [ $TOTD_HTTP -eq 1 ] ; then
+  curl http://192.168.3.16/tips/$SELECTED_TIP 2>/dev/null
 else
-  cat $TIPREPO/$CURTIP.txt
+  cat $TIPREPO/$SELECTED_TIP
 fi
 echo "================================================"
 echo
-
-NEXT=`expr $CURTIP % $NUMTIPS`
-NEXT=`expr $NEXT + 1`
-
-echo $NEXT > ~/.curtip
-


### PR DESCRIPTION
- Change tips.sh to select a random file from tips folder
- Added fallback tips folder path

Tips are now randomly selected from `~/tips` or `./tips` folder. The tip's filename doesn't matter anymore.